### PR TITLE
Use OTAA join

### DIFF
--- a/rev_b/firmware/LoFence/main.c
+++ b/rev_b/firmware/LoFence/main.c
@@ -119,6 +119,14 @@ void rn2483_init() {
 
 	rn2483_tx("sys get hweui\r\n");
 	rn2483_rx();
+	
+	if(strcmp("FFFFFFFFFFFFFFFF", devEui) == 0) {
+		// DevEUI not set, so use hweui
+		strncpy(devEui, buffer_rn, 16);
+		#ifdef DEBUG
+		debug("DevEUI not set. Using HWEUI.\r\n");
+		#endif
+	}
 
 	#ifdef FACTORY_RESET
 	rn2483_tx("sys factoryRESET\r\n");
@@ -132,7 +140,7 @@ void rn2483_init() {
 	rn2483_tx("mac set adr on\r\n");
 	rn2483_rx();
 
-	sprintf (buffer_rn, "mac set devaddr %s\r\n", devAddr);
+	sprintf (buffer_rn, "mac set deveui %s\r\n", devEui);
 	rn2483_tx(buffer_rn);
 	rn2483_rx();
 	if (strcmp(buffer_rn, "ok\r\n") != 0) {
@@ -140,7 +148,7 @@ void rn2483_init() {
 		return;
 	}
 
-	sprintf (buffer_rn, "mac set nwkskey %s\r\n", nwkSKey);
+	sprintf (buffer_rn, "mac set appeui %s\r\n", appEui);
 	rn2483_tx(buffer_rn);
 	rn2483_rx();
 	if (strcmp(buffer_rn, "ok\r\n") != 0) {
@@ -148,10 +156,27 @@ void rn2483_init() {
 		return;
 	}
 
-	sprintf (buffer_rn, "mac set appskey %s\r\n", appSKey);
+	sprintf (buffer_rn, "mac set appkey %s\r\n", appKey);
 	rn2483_tx(buffer_rn);
 	rn2483_rx();
 	if (strcmp(buffer_rn, "ok\r\n") != 0) {
+		rn2483_init_error();
+		return;
+	}
+
+	sprintf (buffer_rn, "mac save\r\n");
+	rn2483_tx(buffer_rn);
+	rn2483_rx();
+	if (strcmp(buffer_rn, "ok\r\n") != 0) {
+		rn2483_init_error();
+		return;
+	}
+	
+	sprintf (buffer_rn, "mac join otaa\r\n");
+	rn2483_tx(buffer_rn);
+	rn2483_rx();
+	rn2483_rx();
+	if (strcmp(buffer_rn, "accepted\r\n") != 0) {
 		rn2483_init_error();
 		return;
 	}

--- a/rev_b/firmware/LoFence/main.h
+++ b/rev_b/firmware/LoFence/main.h
@@ -14,12 +14,12 @@
 #define MEASURE_MS 15000
 
 #include "secret.h"
-// secret.h contains the required keys for ABP
+// secret.h contains the required keys for OTAA
 // Copy from TTN Device Console.
 // Example:
-//   const char *devAddr = "";
-//   const char *nwkSKey = "";
-//   const char *appSKey = "";
+//   char *devEui = "FFFFFFFFFFFFFFFF"; // If set to all FF's here, we will use the Hardware EUI of the RN2483 module.
+//   char *appEui = "0000000000000000"; // The Things Stack uses all 00's by default.
+//   char *appKey = "";                 // Fill in your 32 character AppKey from the console here.
 
 void adc_init();
 


### PR DESCRIPTION
### At startup do an OTAA join.

Device restarts can be detected by looking at the LoRaWAN frame counter.

What about best practices? One should read this paragraph with some extra context:
https://www.thethingsindustries.com/docs/devices/best-practices/#power-cycles

> Devices should save network parameters between regular power cycles. 

The LoFence project does not do "regular restarts". We start up and then remain on and in sleep mode until our battery runs out. We restart after the battery is charged again. This is not a "regular restart". In fact it is quite irregular, and very dependant on the battery type, weather, signal strength (ADR), etc. A "regular restart" is for example if a device restarts at predictable intervals like once per day. This is why I am of the opinion that we are following best practices by doing an OTAA join at every startup.

If one follow the discussion on the TTN Forum, one would have seen that the instruction to migrate an OTAA device from V2 to V3 was to do a power cycle. This is because the assumption is that OTAA devices will rejoin the network when power cycled.

### If DevEUI is set to all FF's, use the hardware EUI of the RN2483 module

In the future I would like to store the three configuration parameters for OTAA (DevEUI, AppKey, NwkKey) in EEPROM. EEPROM defaults to all FF values. This is why I chose to use an all FF value as the default that triggers the code to use the Hardware EUI.

Reference for using EEPROM:
https://github.com/meetjestad/mjs_firmware/blob/fa4c877090320ff35751e46c1b9678b8e6a083f2/mjs_lmic.h#L43-L50
https://github.com/meetjestad/mjs_firmware/blob/fa4c877090320ff35751e46c1b9678b8e6a083f2/mjs_lmic.h#L91-L99
